### PR TITLE
Admin: readUsers, readTweets, deleteTweet

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,14 +7,14 @@ const db = require('./models')
 const routes = require('./routes')
 const helpers = require('./_helpers')
 const bodyParser = require('body-parser')
-const usePassport = require('./config/passport')
+const passport = require('./config/passport')
 
 const app = express()
 const port = process.env.PORT
 
 
 app.use(bodyParser.urlencoded({ extended: true }))
-usePassport(app)
+app.use(passport.initialize())
 routes(app)
 
 app.listen(port, () => {

--- a/config/passport.js
+++ b/config/passport.js
@@ -7,25 +7,45 @@ const db = require('../models')
 const User = db.User
 const Like = db.Like
 
-module.exports = app => {
-  // init Passport 
-  app.use(passport.initialize())
+// set JwtStrategy
+let jwtOptions = {}
+jwtOptions.jwtFromRequest = ExtractJwt.fromAuthHeaderAsBearerToken()
+jwtOptions.secretOrKey = process.env.JWT_SECRET
 
-  // set JwtStrategy
-  let jwtOptions = {}
-  jwtOptions.jwtFromRequest = ExtractJwt.fromAuthHeaderAsBearerToken()
-  jwtOptions.secretOrKey = process.env.JWT_SECRET
+passport.use(new JwtStrategy(jwtOptions, (jwt_payload, done) => {
+  User.findByPk(jwt_payload.id, {
+    include: [
+      Like,
+      { model: User, as: 'Followers' },
+      { model: User, as: 'Followings' }
+    ]
+  }).then(user => {
+    if (!user) return done(null, false)
+    return done(null, user)
+  })
+}))
 
-  passport.use(new JwtStrategy(jwtOptions, (jwt_payload, done) => {
-    User.findByPk(jwt_payload.id, {
-      include: [
-        Like,
-        { model: User, as: 'Followers' },
-        { model: User, as: 'Followings' }
-      ]
-    }).then(user => {
-      if (!user) return done(null, false)
-      return done(null, user)
-    })
-  }))
-}
+module.exports = passport
+
+// module.exports = app => {
+//   // init Passport 
+//   app.use(passport.initialize())
+
+//   // set JwtStrategy
+//   let jwtOptions = {}
+//   jwtOptions.jwtFromRequest = ExtractJwt.fromAuthHeaderAsBearerToken()
+//   jwtOptions.secretOrKey = process.env.JWT_SECRET
+
+//   passport.use(new JwtStrategy(jwtOptions, (jwt_payload, done) => {
+//     User.findByPk(jwt_payload.id, {
+//       include: [
+//         Like,
+//         { model: User, as: 'Followers' },
+//         { model: User, as: 'Followings' }
+//       ]
+//     }).then(user => {
+//       if (!user) return done(null, false)
+//       return done(null, user)
+//     })
+//   }))
+// }

--- a/controllers/adminController.js
+++ b/controllers/adminController.js
@@ -1,8 +1,30 @@
 const helpers = require('../_helpers')
+const db = require('../models')
+const User = db.User
+const Tweet = db.Tweet
+const Like = db.Like
 
 const adminController = {
   readUsers: (req, res) => {
-    res.send(`Hello Admin ${helpers.getUser(req).name}!`)
+    User.findAll({
+      where: { role: 'user' },
+      include: [
+        Tweet,
+        Like,
+        { model: User, as: 'Followers' },
+        { model: User, as: 'Followings' },
+      ]
+    }).then(users => {
+      users = users.map(user => ({
+        ...(Object.fromEntries(Object.entries(user.dataValues).slice(0, 11))),
+        tweetsCount: user.dataValues.Tweets.length,
+        likesCount: user.dataValues.Likes.length,
+        followersCount: user.dataValues.Followers.length,
+        followingsCount: user.dataValues.Followings.length
+      }))
+      users = users.sort((a, b) => b.tweetsCount - a.tweetsCount)
+      return res.json(users)
+    }).catch(err => console.error(err))
   },
   deleteTweet: (req, res) => {
 

--- a/controllers/adminController.js
+++ b/controllers/adminController.js
@@ -35,7 +35,20 @@ const adminController = {
     }).then(tweets => res.json(tweets))
   },
   deleteTweet: (req, res) => {
+    const id = Number(req.params.id)
+    Tweet.findByPk(id).then(tweet => {
+      if (!tweet) return res.json({
+        status: 'failure',
+        message: `tweets/${id} do not exit!`,
+        tweet
+      })
 
+      return tweet.destroy().then(tweet => res.json({
+        status: 'success',
+        message: `tweets/${tweet.id} is deleted successfully`,
+        tweet
+      }))
+    })
   }
 }
 

--- a/controllers/adminController.js
+++ b/controllers/adminController.js
@@ -26,6 +26,14 @@ const adminController = {
       return res.json(users)
     }).catch(err => console.error(err))
   },
+  readTweets: (req, res) => {
+    Tweet.findAll({
+      include: [{
+        model: User,
+        attributes: ['id', 'account', 'name', 'avatar']
+      }]
+    }).then(tweets => res.json(tweets))
+  },
   deleteTweet: (req, res) => {
 
   }

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,8 +1,15 @@
-const passport = require('passport')
+const passport = require('../config/passport')
 const helpers = require('../_helpers')
 
 module.exports = {
-  authenticated: passport.authenticate('jwt', { session: false }),
+  authenticate: (req, res, next) => {
+    passport.authenticate('jwt', { session: false }, (err, user, info) => {
+      if (err) return next(err)
+      if (!user) return res.status(401).json({ status: 'failure', message: info.message })
+      req.user = user
+      return next()
+    })(req, res, next)
+  },
   authAdmin: (req, res, next) => {
     const user = helpers.getUser(req)
     if (user) {

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -4,6 +4,7 @@ const router = express.Router()
 const adminController = require('../controllers/adminController')
 
 router.get('/users', adminController.readUsers)
+router.get('/tweets', adminController.readTweets)
 router.delete('/tweets/:id', adminController.deleteTweet)
 
 module.exports = router

--- a/routes/index.js
+++ b/routes/index.js
@@ -4,12 +4,12 @@ const users = require('./users')
 const tweets = require('./tweets')
 const followships = require('./followships')
 
-const { authenticated, authAdmin, authUser } = require('../middleware/auth')
+const { authenticate, authAdmin, authUser } = require('../middleware/auth')
 
 module.exports = (app) => {
   app.use('/api', auth)
-  app.use('/api/admin', authenticated, authAdmin, admin)
-  app.use('/api/users/:id', authenticated, authUser, users)
-  app.use('/api/tweets', authenticated, authUser, tweets)
-  app.use('/api/followships', authenticated, authUser, followships)
+  app.use('/api/admin', authenticate, authAdmin, admin)
+  app.use('/api/users/:id', authenticate, authUser, users)
+  app.use('/api/tweets', authenticate, authUser, tweets)
+  app.use('/api/followships', authenticate, authUser, followships)
 }


### PR DESCRIPTION
## Brief
- 皆已通過本地自動化測試，並符合以下 user story
- 修正 passport 的引入方式，並重新封裝 `authenticate` ，以符合自動化測試

## Test case
### readUsers: GET /api/admin/users
- 管理者可以瀏覽站內所有的使用者清單
- 使用者社群活躍數據，包括推播數量、關注人數、跟隨者人數、推文被 like 的數量
- 清單按推文數排序

### readTweets: GET /api/admin/tweets
- 管理者可以瀏覽全站的 Tweet 清單（tweet 要包含 user 的資料）

### deleteTweet: DELETE /api/admin/tweets/:id
- 管理者可以在清單上直接刪除任何人的推文

---
先 POST /api/login 
> account: @root , password:12345678
複製 token 到 header


再麻煩協助在測試機上測試，感謝！