### PR TITLE
feat: add GET /api/current_user

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -18,7 +18,8 @@ passport.use(new JwtStrategy(jwtOptions, (jwt_payload, done) => {
       Like,
       { model: User, as: 'Followers' },
       { model: User, as: 'Followings' }
-    ]
+    ],
+    attributes: { exclude: ['password'] }
   }).then(user => {
     if (!user) return done(null, false)
     return done(null, user.toJSON())

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -80,6 +80,11 @@ const authController = {
         message: `account: '${user.account}' is registered successfully!`
       })
     }).catch(next)
+  },
+
+  getCurrentUser: (req, res, next) => {
+    const currentUser = Object.fromEntries(Object.entries(req.user).slice(0, 8))
+    return res.json(currentUser)
   }
 }
 

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -2,8 +2,10 @@ const express = require('express')
 const router = express.Router()
 
 const authController = require('../controllers/authController')
+const { authenticate } = require('../middleware/auth')
 
 router.post('/login', authController.login)
 router.post('/users', authController.register)
+router.get('/current_user', authenticate, authController.getCurrentUser)
 
 module.exports = router


### PR DESCRIPTION
前端能 [切換頁面時維持登入狀態](https://lighthouse.alphacamp.co/courses/45/units/7831)

拿到當前使用者的資料

```
{
    "id": 81,
    "email": "wolverine@xmen.org",
    "name": "Logan",
    "avatar": null,
    "introduction": null,
    "account": "@wolverine",
    "cover": "0",
    "role": "user"
}
```